### PR TITLE
modify-settings-on-typingland: CanvasHeight&CommentMax are mininised

### DIFF
--- a/init.xml
+++ b/init.xml
@@ -1,8 +1,8 @@
 <setting>
   <FrameRate>60</FrameRate>
   <CanvasWidth>316</CanvasWidth>
-  <CanvasHeight>896</CanvasHeight>
-  <CommentMax>28</CommentMax>
+  <CanvasHeight>670</CanvasHeight>
+  <CommentMax>20</CommentMax>
   <LoadInterbal>500</LoadInterbal>
   <SkinHeight>32</SkinHeight>
   <SkinWidth>316</SkinWidth>


### PR DESCRIPTION
WebCam表示欄を挿入したため，コメント表示欄高さが狭くなったので

1. キャンバス高さ`CanvasHeight`
2. コメント最大表示数`CommentMax`

を小さくした．
![image](https://user-images.githubusercontent.com/17232984/140717450-7d8fc9cf-a0d3-40bb-909d-a0424a679903.png)
![image](https://user-images.githubusercontent.com/17232984/140717466-8b58098a-de04-4695-bfda-3edd2a8ed68c.png)
![image](https://user-images.githubusercontent.com/17232984/140717476-0eef1c1c-f08b-4f1d-b16d-377a38dbecd5.png)
![image](https://user-images.githubusercontent.com/17232984/140717488-a608fa59-0468-4fc5-9141-502fb4881576.png)
![image](https://user-images.githubusercontent.com/17232984/140717499-506abd17-7b62-4782-b33f-b48a4cca510a.png)
