### PR TITLE
NiCommentGeneratorとの連動でコメントが流れない問題への対応

### DIFF
--- a/comment.xml
+++ b/comment.xml
@@ -1,3 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <log>
+  <comment no="" time="" owner="" service="" handle=""></comment>
 </log>


### PR DESCRIPTION
NiCommentGeneratorとの連動において，comment.xmlに何かしらのコメントデータがないとコメントが流れないようなのでダミーコメントを追加．